### PR TITLE
Update pytorch_2.5.0.bb

### DIFF
--- a/recipes-devtools/pytorch/pytorch_2.5.0.bb
+++ b/recipes-devtools/pytorch/pytorch_2.5.0.bb
@@ -48,6 +48,7 @@ EXTRA_OECMAKE += " \
     -DUSE_CUSPARSELT=OFF \
     -DPROTOBUF_PROTOC_EXECUTABLE=${STAGING_BINDIR_NATIVE}/protoc \
     -DUSE_SYSTEM_PYBIND11=ON \
+    -DCMAKE_CXX_FLAGS="-include cstdint" \
 "
 
 # Disable installing the fmt third-party library, which may cause conflicts


### PR DESCRIPTION
Fix build with GCC 15 by adding -include cstdint to CMAKE_CXX_FLAGS to EXTRA_OECMAKE.

Added -DCMAKE_CXX_FLAGS="-include cstdint" to the build recipe to fix compilation errors with GCC 15 (e.g., 'uint8_t' was not declared in this scope). This resolves issues when building PyTorch in the tegra-demo-distro using the meta-tegra master branch (L4T R36.4.3 / JetPack 6.2).